### PR TITLE
fix: remove feature declaration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(osstring_ascii)]
-
 //! Normalized Paths
 //!
 //! `npath` is a Rust library providing methods for cross-platform lexical path processing and


### PR DESCRIPTION
The feature `osstring_ascii` has been resolved and merged into stable channel. Remove this declaration will allow this crate used in stable channel.